### PR TITLE
Fixed gmail icon redirect

### DIFF
--- a/home.html
+++ b/home.html
@@ -31,7 +31,7 @@
             <span class="job">Web Developer</span>
         </div>
         <div class="media-buttons">
-            <a href="https://mail.google.com/mail/u/0/#inbox" style="background:#f10f0f;" class="link">
+            <a id="gmailIcon" href="javascript:void(0);" style="background:#f10f0f;" class="link">
                 <i class='bx bxl-gmail'></i>
             </a>
             <a href="https://github.com/muskanchoudhary001" style="background:#161617;" class="link">
@@ -48,7 +48,8 @@
             <div class="button" onclick="window.location.href='https://github.com/muskanchoudhary001';">
                 Follow me
             </div>
-            <div class="button" onclick="window.location.href='https://www.linkedin.com/in/muskan-choudhary-789759175/';">
+            <div class="button"
+                onclick="window.location.href='https://www.linkedin.com/in/muskan-choudhary-789759175/';">
                 Message
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -43,3 +43,16 @@ let count = 0;
             count++;
             counter.innerHTML = `${count}`;
         }
+
+        // Get the Gmail icon element
+        const gmailIcon = document.getElementById('gmailIcon');
+
+        // Define the recipient email
+        const recipientEmail = 'youremail@mail.com';  // REPLACE THIS WITH THE ACTUAL EMAIL ID
+
+        // Add click event listener to the Gmail icon
+        gmailIcon.addEventListener('click', function ()
+        {
+        // Open Gmail's compose window with the recipient email pre-filled
+        window.open(`https://mail.google.com/mail/?view=cm&fs=1&to=${recipientEmail}`, '_blank');
+        });


### PR DESCRIPTION
Solution / Proposed Code for issue #4 

Modified the Gmail icon link to redirect to the compose email tab with the recipient's email address pre-filled.

Note-
in script.js
![image](https://github.com/user-attachments/assets/728fdb1e-6c5d-495a-abc4-08bf7394b13b)

change "youemail@mail.com" to the person's actual email id.

